### PR TITLE
feat: add ResolveFlag and deterministic reverse lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # go-emoji-flags
 
-Converts a string country code to an emoji in Go.
+Resolves country identifiers (codes, names, aliases) to emoji flags in Go.
 
 ## Features
 
 - ✅ Support for ISO 3166-1 alpha-2 codes (e.g., "VN")
 - ✅ Support for ISO 3166-1 alpha-3 codes (e.g., "VNM") 
 - ✅ Support for CIOC codes (e.g., "GER")
+- ✅ Support for full country names and aliases (e.g., "Vietnam", "UK")
 - ✅ Support for Great Britain subdivisions (England, Scotland, Wales)
 - ✅ Fuzzy matching for typos and variations (e.g., "USA" → "US", "GERM" → "GER")
 - ✅ Consistent emoji output length (no trailing spaces)
@@ -38,13 +39,28 @@ func main() {
 }
 ```
 
+### Resolve Mixed Input (Recommended)
+
+Use `ResolveFlag()` for input that may be a code, alias, or country name:
+
+```go
+flag, code, kind := emoji.ResolveFlag("United States")
+fmt.Printf("%s %s (%s)\n", flag, code, kind) // 🇺🇸 US (name)
+
+flag, code, kind = emoji.ResolveFlag("UK")
+fmt.Printf("%s %s (%s)\n", flag, code, kind) // 🇬🇧 GB (alias)
+
+flag, code, kind = emoji.ResolveFlag("GERM")
+fmt.Printf("%s %s (%s)\n", flag, code, kind) // 🇩🇪 GER (fuzzy-code)
+```
+
 ### Reverse Lookup (Flag to Code)
 
 Convert flag emojis back to country codes:
 
 ```go
 code := emoji.GetCode("🇻🇳")    // Returns "VN"
-code := emoji.GetCode("🏴󠁧󠁢󠁥󠁮󠁧󠁿")  // Returns "GB-ENG"
+code := emoji.GetCode("🏴")  // Returns "GB-ENG" (deterministic default)
 ```
 
 ### Get Country Names
@@ -182,6 +198,8 @@ BenchmarkGetFlagFuzzyClose-12       13245    90293 ns/op  194969 B/op   4261 all
 ### `GetFlag(countryCode string) string`
 Converts a country code to its emoji flag. Supports ISO 3166-1 alpha-2, alpha-3, CIOC codes, and special subdivisions.
 
+This is a strict code lookup API. For mixed user input, use `ResolveFlag()`.
+
 **Parameters:**
 - `countryCode` - 2-letter (VN), 3-letter (VNM, GER), or special codes (GB-ENG)
 
@@ -197,6 +215,8 @@ Finds a flag using fuzzy matching (Levenshtein distance ≤ 2). Prefers shorter 
 
 ### `GetCode(flag string) string`
 Converts a flag emoji to its ISO 3166-1 alpha-2 country code.
+
+For the black flag (`🏴`) shared by GB subdivisions, this function returns `GB-ENG` as deterministic default.
 
 **Parameters:**
 - `flag` - Flag emoji (e.g., 🇻🇳)
@@ -218,6 +238,17 @@ Finds a flag by country name using exact or fuzzy matching (Levenshtein distance
 - `name` - Country name or alias (e.g., "Vietnam", "USA", "UK")
 
 **Returns:** Flag emoji and matched code, or empty strings if no match
+
+### `ResolveFlag(input string) (string, string, string)`
+Resolves mixed identifiers using this order: exact code, exact alias/name, fuzzy code, fuzzy name.
+
+**Parameters:**
+- `input` - Country code, alias, or country name
+
+**Returns:**
+- Flag emoji
+- Matched code
+- Match kind: `code`, `alias`, `name`, `fuzzy-code`, or `fuzzy-name`
 
 ## Data Maps
 

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -1,0 +1,189 @@
+# Migration and Scope Expansion Plan
+
+This document is the working execution checklist for expanding project scope from code-only lookups to country identifier resolution, and for rebranding the repository/module safely.
+
+## Goals
+
+- Expand scope to support country identifiers:
+  - ISO 3166-1 alpha-2 codes
+  - ISO 3166-1 alpha-3 codes
+  - CIOC codes
+  - Full country names and aliases
+- Keep behavior deterministic and testable.
+- Rebrand repository and description.
+- Assess and execute module path migration with controlled breaking change.
+
+## Rollout Strategy
+
+Execute in 3 PRs to reduce risk:
+
+1. API/behavior hardening (no rename)
+2. Repository rebrand and docs refresh
+3. Optional module path migration (`go.mod`) with migration notes
+
+---
+
+## PR1 - Scope Expansion and Deterministic Behavior
+
+### Objectives
+
+- Introduce a unified resolver for mixed user input.
+- Preserve existing APIs.
+- Remove nondeterministic behavior.
+
+### Changes
+
+- `emoji_flags.go`
+  - Add unified resolver API (example):
+    - `ResolveFlag(input string) (flag string, matched string, kind string)`
+  - Resolver precedence:
+    1. Exact code (`alpha-2`, `alpha-3`, `CIOC`, special code)
+    2. Exact alias/name
+    3. Fuzzy fallback
+  - Update `GetFlagByName` to perform exact alias lookup before fuzzy matching.
+  - Make special reverse lookup deterministic for `GetCode("🏴")`.
+    - Avoid unordered map iteration for return value selection.
+
+- `emoji_flags_test.go`
+  - Add tests for resolver precedence and expected outputs.
+  - Add deterministic tests for special flag reverse lookup.
+  - Add exact alias tests (`USA`, `UK`, `UAE`) independent of fuzzy behavior.
+
+- `README.md`
+  - Add resolver usage section.
+  - Clarify `GetFlag` as strict code lookup.
+
+- `playground/main.go`
+  - Fix `VietNamCode` to `VietnamCode`.
+
+### Validation
+
+- Run: `go test ./...`
+- Ensure no flaky tests caused by map iteration randomness.
+
+### Suggested PR title
+
+- `feat: add unified country identifier resolver and deterministic lookups`
+
+---
+
+## PR2 - Repository Rebrand and Metadata Update
+
+### Objectives
+
+- Reposition project publicly without immediate module-breaking change.
+
+### Changes
+
+- GitHub repository settings (manual)
+  - Rename repository.
+  - Update repository description and topics.
+
+- `README.md`
+  - Update title and positioning text.
+  - Update badges and repository links.
+  - Keep module import path unchanged if PR3 is not merged yet.
+
+### Validation
+
+- Confirm GitHub URL redirect works.
+- Confirm badges and links render correctly.
+- Run: `go test ./...`
+
+### Suggested PR title
+
+- `docs: rebrand repository and update project positioning`
+
+---
+
+## PR3 - Module Path Migration (`go.mod`) [Breaking]
+
+### Objectives
+
+- Align module path with renamed repository.
+
+### Changes
+
+- `go.mod`
+  - Change module path:
+    - from `github.com/yudgnahk/go-emoji-flags`
+    - to `github.com/yudgnahk/<new-repo-name>`
+
+- `crawler/crawler.go`
+  - Update module import path references.
+
+- `README.md`
+  - Update `go get` command and import snippets.
+  - Add migration section with copy/paste replacement guidance.
+
+- Repository-wide cleanup
+  - Replace all remaining references to old module path.
+
+### Validation
+
+- Run: `go test ./...`
+- Run: `go list ./...`
+- Smoke test in a temp module:
+  - `go mod init tmp`
+  - `go get github.com/yudgnahk/<new-repo-name>@<tag>`
+
+### Suggested PR title
+
+- `chore!: migrate module path to new repository name`
+
+---
+
+## Impact Assessment: Repo Rename vs `go.mod` Change
+
+### Rename repository only
+
+- Lower risk for consumers in short term.
+- GitHub URL redirects generally preserve access.
+- Existing Go module imports can continue if module path remains unchanged.
+
+### Rename repository and change module path
+
+- Breaking for all downstream consumers.
+- Consumers must update imports to the new module path.
+- Requires clear migration notes and release communication.
+
+---
+
+## Release Plan
+
+1. Release after PR1 (functional improvement, non-breaking intent).
+2. Release after PR2 (branding/docs refresh).
+3. Release after PR3 with explicit breaking-change migration notes.
+
+Include in changelog:
+
+- New resolver API
+- Deterministic special-flag behavior
+- Import path migration instructions (if PR3 merged)
+
+---
+
+## Migration Notes Template (for README)
+
+```text
+Old import:
+  github.com/yudgnahk/go-emoji-flags
+
+New import:
+  github.com/yudgnahk/<new-repo-name>
+```
+
+Recommended command-line replacement:
+
+```bash
+rg -l 'github.com/yudgnahk/go-emoji-flags' | xargs sed -i '' 's#github.com/yudgnahk/go-emoji-flags#github.com/yudgnahk/<new-repo-name>#g'
+```
+
+Note: verify `sed -i` behavior on your OS/shell before bulk replacement.
+
+---
+
+## Current Known Issues to Address During PR1
+
+- `GetCode("🏴")` currently has ambiguous mapping behavior due to special flag reuse.
+- `playground/main.go` references `VietNamCode` but generated constant is `VietnamCode`.

--- a/emoji_flags.go
+++ b/emoji_flags.go
@@ -4,6 +4,18 @@ import (
 	"strings"
 )
 
+const (
+	ResolveKindCode      = "code"
+	ResolveKindAlias     = "alias"
+	ResolveKindName      = "name"
+	ResolveKindFuzzyCode = "fuzzy-code"
+	ResolveKindFuzzyName = "fuzzy-name"
+
+	englandTagFlag  = "\U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006E\U000E0067\U000E007F"
+	scotlandTagFlag = "\U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F"
+	walesTagFlag    = "\U0001F3F4\U000E0067\U000E0062\U000E0077\U000E006C\U000E0073\U000E007F"
+)
+
 var SpecialEmojiMap = map[string]string{
 	EnglandCode:      "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
 	ScotlandCode:     "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
@@ -172,11 +184,21 @@ func levenshtein(s1, s2 string) int {
 //	code := emojiflags.GetCode("🇻🇳")  // Returns "VN"
 //	code := emojiflags.GetCode("🏴󠁧󠁢󠁥󠁮󠁧󠁿")  // Returns "GB-ENG"
 func GetCode(flag string) string {
-	// Check special flags first
-	for code, emoji := range SpecialEmojiMap {
-		if emoji == flag {
-			return code
-		}
+	// Check special flags first.
+	if flag == englandTagFlag {
+		return EnglandCode
+	}
+	if flag == scotlandTagFlag {
+		return ScotlandCode
+	}
+	if flag == walesTagFlag {
+		return WalesCode
+	}
+
+	// The plain black flag emoji is shared across subdivisions,
+	// so we use England as deterministic default.
+	if flag == "🏴" {
+		return EnglandCode
 	}
 
 	// Check if it's a standard flag emoji (two regional indicator symbols)
@@ -206,6 +228,44 @@ func GetCode(flag string) string {
 	}
 
 	return ""
+}
+
+// ResolveFlag resolves mixed country identifiers to a flag.
+// It supports exact code, exact alias/name, then fuzzy code/name matching.
+// Returns the flag, matched code, and match kind.
+func ResolveFlag(input string) (string, string, string) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", "", ""
+	}
+
+	normalized := strings.ToUpper(input)
+
+	if flag := GetFlag(normalized); flag != "" {
+		return flag, normalized, ResolveKindCode
+	}
+
+	if code, ok := CountryAliases[normalized]; ok {
+		if flag := GetFlag(code); flag != "" {
+			return flag, code, ResolveKindAlias
+		}
+	}
+
+	for code, countryName := range CountryNames {
+		if strings.ToUpper(countryName) == normalized {
+			return GetFlag(code), code, ResolveKindName
+		}
+	}
+
+	if flag, code := GetFlagFuzzy(normalized); flag != "" {
+		return flag, code, ResolveKindFuzzyCode
+	}
+
+	if flag, code := GetFlagByName(normalized); flag != "" {
+		return flag, code, ResolveKindFuzzyName
+	}
+
+	return "", "", ""
 }
 
 // GetName converts a country code or flag emoji to its country name.
@@ -274,6 +334,10 @@ func GetFlagByName(name string) (string, string) {
 		if strings.ToUpper(countryName) == name {
 			return GetFlag(code), code
 		}
+	}
+
+	if code, ok := CountryAliases[name]; ok {
+		return GetFlag(code), code
 	}
 
 	// Try fuzzy matching with country names

--- a/emoji_flags.go
+++ b/emoji_flags.go
@@ -245,15 +245,15 @@ func ResolveFlag(input string) (string, string, string) {
 		return flag, normalized, ResolveKindCode
 	}
 
-	if code, ok := CountryAliases[normalized]; ok {
-		if flag := GetFlag(code); flag != "" {
-			return flag, code, ResolveKindAlias
-		}
-	}
-
 	for code, countryName := range CountryNames {
 		if strings.ToUpper(countryName) == normalized {
 			return GetFlag(code), code, ResolveKindName
+		}
+	}
+
+	if code, ok := CountryAliases[normalized]; ok {
+		if flag := GetFlag(code); flag != "" {
+			return flag, code, ResolveKindAlias
 		}
 	}
 

--- a/emoji_flags.go
+++ b/emoji_flags.go
@@ -17,10 +17,10 @@ const (
 )
 
 var SpecialEmojiMap = map[string]string{
-	EnglandCode:      "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
-	ScotlandCode:     "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
-	WalesCode:        "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
-	EnglandShortCode: "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
+	EnglandCode:      englandTagFlag,
+	ScotlandCode:     scotlandTagFlag,
+	WalesCode:        walesTagFlag,
+	EnglandShortCode: englandTagFlag,
 }
 
 // GetFlag converts a country code (ISO 3166-1 alpha-2, alpha-3, or CIOC) to its corresponding emoji flag.

--- a/emoji_flags_test.go
+++ b/emoji_flags_test.go
@@ -372,6 +372,8 @@ func Test_ResolveFlag(t *testing.T) {
 		{"Exact CIOC code", "GER", true, "GER", ResolveKindCode},
 		{"Exact alias in code set", "USA", true, "USA", ResolveKindCode},
 		{"Exact country name", "Vietnam", true, "VN", ResolveKindName},
+		{"Exact subdivision name", "England", true, "GB-ENG", ResolveKindName},
+		{"Exact subdivision name Scotland", "Scotland", true, "GB-SCT", ResolveKindName},
 		{"Alias UK", "UK", true, "GB", ResolveKindAlias},
 		{"Fuzzy code", "GERM", true, "GER", ResolveKindFuzzyCode},
 		{"Fuzzy name", "Viet Namm", true, "VN", ResolveKindFuzzyName},

--- a/emoji_flags_test.go
+++ b/emoji_flags_test.go
@@ -280,7 +280,7 @@ func Test_GetCode(t *testing.T) {
 		{"Vietnam flag", "🇻🇳", "VN"},
 		{"US flag", "🇺🇸", "US"},
 		{"Germany flag", "🇩🇪", "DE"},
-		{"England special flag", "🏴󠁧󠁢󠁥󠁮󠁧󠁿", "GB-ENG"},
+		{"England special flag", "🏴", "GB-ENG"},
 		{"Scotland special flag", "🏴󠁧󠁢󠁳󠁣󠁴󠁿", "GB-SCT"},
 		{"Wales special flag", "🏴󠁧󠁢󠁷󠁬󠁳󠁿", "GB-WLS"},
 		{"Invalid flag", "🎌", ""},
@@ -354,6 +354,55 @@ func Test_GetFlagByName(t *testing.T) {
 				if gotFlag != "" || gotCode != "" {
 					t.Errorf("GetFlagByName() expected empty, got flag=%v, code=%v", gotFlag, gotCode)
 				}
+			}
+		})
+	}
+}
+
+func Test_ResolveFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantFlag bool
+		wantCode string
+		wantKind string
+	}{
+		{"Exact alpha-2 code", "VN", true, "VN", ResolveKindCode},
+		{"Exact alpha-3 code", "VNM", true, "VNM", ResolveKindCode},
+		{"Exact CIOC code", "GER", true, "GER", ResolveKindCode},
+		{"Exact alias in code set", "USA", true, "USA", ResolveKindCode},
+		{"Exact country name", "Vietnam", true, "VN", ResolveKindName},
+		{"Alias UK", "UK", true, "GB", ResolveKindAlias},
+		{"Fuzzy code", "GERM", true, "GER", ResolveKindFuzzyCode},
+		{"Fuzzy name", "Viet Namm", true, "VN", ResolveKindFuzzyName},
+		{"Invalid", "NOTACOUNTRY", false, "", ""},
+		{"Empty", "", false, "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFlag, gotCode, gotKind := ResolveFlag(tt.input)
+
+			if tt.wantFlag {
+				if gotFlag == "" {
+					t.Errorf("ResolveFlag() expected non-empty flag")
+				}
+				if !utf8.ValidString(gotFlag) {
+					t.Errorf("ResolveFlag() expected valid utf8 flag, got %v", gotFlag)
+				}
+				if GetPrintableLength(gotFlag) == 0 {
+					t.Errorf("ResolveFlag() expected printable flag")
+				}
+			} else if gotFlag != "" || gotCode != "" || gotKind != "" {
+				t.Errorf("ResolveFlag() expected empty outputs, got flag=%v code=%v kind=%v", gotFlag, gotCode, gotKind)
+			}
+
+			if gotCode != tt.wantCode {
+				t.Errorf("ResolveFlag() code = %v, want %v", gotCode, tt.wantCode)
+			}
+
+			if gotKind != tt.wantKind {
+				t.Errorf("ResolveFlag() kind = %v, want %v", gotKind, tt.wantKind)
 			}
 		})
 	}


### PR DESCRIPTION
## What
- add ResolveFlag(input) as the recommended mixed-identifier resolver (code/alias/name + fuzzy fallback)
- add ResolveKind constants to classify resolver match source
- make GetCode deterministic for GB subdivision black flags and explicit for tag flag variants
- make GetFlagByName do exact alias lookup before fuzzy matching
- update README with resolver usage and API docs
- add docs/migration-plan.md with phased rollout plan

## Why
This is PR1 of the scope expansion plan: move from code-only framing toward country identifier resolution while preserving existing APIs.

## Qodo Review Fixes
- ResolveFlag now checks CountryNames before CountryAliases so inputs like "England" are classified as kind=name instead of kind=alias
- SpecialEmojiMap now uses tag flag constants (englandTagFlag, scotlandTagFlag, walesTagFlag) so subdivision flags have distinct identity and reverse lookups preserve correct codes

## Validation
- go test ./...

## Notes
- playground/main.go had a local typo fix (VietNamCode -> VietnamCode) but that file was intentionally not included in this PR to keep PR1 focused.